### PR TITLE
Re-add AbstractPublisherImpl which exposes GhostWriter fix compatibility issues

### DIFF
--- a/src/main/java/hudson/plugins/cppncss/CppNCSSGhostwriter.java
+++ b/src/main/java/hudson/plugins/cppncss/CppNCSSGhostwriter.java
@@ -50,24 +50,21 @@ public class CppNCSSGhostwriter
     public boolean performFromMaster(Run<?, ?> build, FilePath executionRoot, TaskListener listener)
             throws InterruptedException, IOException {
     	if (targets != null && targets.length > 0) {
-	    	List<Action> actions = build.getActions();
+	    	List<CppNCSSBuildIndividualReport> actions = build.getActions(CppNCSSBuildIndividualReport.class);
 	    	Result buildResult = build.getResult();
 	    	if (buildResult == null) {
 	    	    // The entire method need to be modified to support Pipeline
 	    	    throw new AbortException("Cannot perform publisher for a running job. The plugin needs to be updated to support plugins like Any Build Step. File a JIRA ticket if you need that");
             }
 
-	    	for (Action action : actions) {
-				if(action instanceof CppNCSSBuildIndividualReport) {
-					CppNCSSBuildIndividualReport cppncssAction = (CppNCSSBuildIndividualReport)action;
-					cppncssAction.setBuild(build);
-	                for (CppNCSSHealthTarget target : targets) {
-	                    Result result = target.evaluateStability(cppncssAction);
-	                    if(result.isWorseThan(buildResult)){
-	                    	buildResult = result;
-	                    }
-	                }
-				}
+	    	for (CppNCSSBuildIndividualReport action : actions) {
+                action.setBuild(build);
+                for (CppNCSSHealthTarget target : targets) {
+                    Result result = target.evaluateStability(action);
+                    if(result.isWorseThan(buildResult)){
+                        buildResult = result;
+                    }
+                }
 			}
 	    	build.setResult(buildResult);
     	}

--- a/src/main/java/hudson/plugins/cppncss/CppNCSSGhostwriter.java
+++ b/src/main/java/hudson/plugins/cppncss/CppNCSSGhostwriter.java
@@ -2,6 +2,7 @@ package hudson.plugins.cppncss;
 
 import hudson.AbortException;
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.HealthReport;
 import hudson.model.Result;
@@ -28,7 +29,7 @@ import org.xmlpull.v1.XmlPullParserException;
  */
 public class CppNCSSGhostwriter
         implements Ghostwriter,
-        Ghostwriter.MasterGhostwriter,
+        Ghostwriter.MasterGhostwriter2,
         Ghostwriter.SlaveGhostwriter {
 
     private final String reportFilenamePattern;

--- a/src/main/java/hudson/plugins/cppncss/CppNCSSPublisher.java
+++ b/src/main/java/hudson/plugins/cppncss/CppNCSSPublisher.java
@@ -2,22 +2,14 @@ package hudson.plugins.cppncss;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.plugins.helpers.AbstractPublisherImpl;
 import org.jenkinsci.Symbol;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractProject;
-import hudson.model.Result;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.plugins.helpers.BuildProxy;
 import hudson.plugins.helpers.Ghostwriter;
 import hudson.plugins.helpers.health.HealthMetric;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
-import hudson.tasks.Recorder;
-import jenkins.tasks.SimpleBuildStep;
-import java.io.IOException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -27,7 +19,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Stephen Connolly
  * @since 08-Jan-2008 21:24:06
  */
-public class CppNCSSPublisher extends Recorder implements SimpleBuildStep {
+public class CppNCSSPublisher extends AbstractPublisherImpl {
 
     private String reportFilenamePattern;
     private Integer functionCcnViolationThreshold = 10;
@@ -67,18 +59,9 @@ public class CppNCSSPublisher extends Recorder implements SimpleBuildStep {
         return BuildStepMonitor.NONE;
     }
 
-    private Ghostwriter newGhostwriter() {
-        return new CppNCSSGhostwriter(reportFilenamePattern, functionCcnViolationThreshold, functionNcssViolationThreshold, targets);
-    }
-
     @Override
-    public void perform(Run<?,?> run, FilePath workspace, Launcher launcher, TaskListener listener) {
-        try {
-            BuildProxy.doPerform(newGhostwriter(), run, workspace, listener);
-        } catch (IOException | InterruptedException e) {
-            run.setResult(Result.FAILURE);
-            e.printStackTrace(listener.getLogger());
-        }
+    public Ghostwriter newGhostwriter() {
+        return new CppNCSSGhostwriter(reportFilenamePattern, functionCcnViolationThreshold, functionNcssViolationThreshold, targets);
     }
 
     @Extension @Symbol("cppncss")

--- a/src/main/java/hudson/plugins/helpers/AbstractPublisherImpl.java
+++ b/src/main/java/hudson/plugins/helpers/AbstractPublisherImpl.java
@@ -1,0 +1,47 @@
+package hudson.plugins.helpers;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.Recorder;
+import jenkins.tasks.SimpleBuildStep;
+
+import java.io.IOException;
+
+/**
+ * An abstract Publisher that is designed to work with a Ghostwriter.
+ *
+ * @author Stephen Connolly
+ * @since 28-Jan-2008 22:32:46
+ */
+public abstract class AbstractPublisherImpl extends Recorder implements SimpleBuildStep {
+
+    /**
+     * Creates the configured Ghostwriter.
+     *
+     * @return returns the configured Ghostwriter.
+     */
+    protected abstract Ghostwriter newGhostwriter();
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener)
+            throws InterruptedException, IOException {
+        return BuildProxy.doPerform(newGhostwriter(), build, listener);
+    }
+
+    @Override
+    public void perform(Run<?,?> run, FilePath workspace, Launcher launcher, TaskListener listener) {
+        try {
+            BuildProxy.doPerform(newGhostwriter(), run, workspace, listener);
+        } catch (IOException | InterruptedException e) {
+            run.setResult(Result.FAILURE);
+            e.printStackTrace(listener.getLogger());
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/helpers/AbstractPublisherImpl.java
+++ b/src/main/java/hudson/plugins/helpers/AbstractPublisherImpl.java
@@ -2,8 +2,6 @@ package hudson.plugins.helpers;
 
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -26,14 +24,6 @@ public abstract class AbstractPublisherImpl extends Recorder implements SimpleBu
      * @return returns the configured Ghostwriter.
      */
     protected abstract Ghostwriter newGhostwriter();
-
-    /**
-     * {@inheritDoc}
-     */
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, final BuildListener listener)
-            throws InterruptedException, IOException {
-        return BuildProxy.doPerform(newGhostwriter(), build, listener);
-    }
 
     @Override
     public void perform(Run<?,?> run, FilePath workspace, Launcher launcher, TaskListener listener) {

--- a/src/main/java/hudson/plugins/helpers/BuildProxy.java
+++ b/src/main/java/hudson/plugins/helpers/BuildProxy.java
@@ -98,12 +98,12 @@ public final class BuildProxy implements Serializable {
         }
 
         // finally, on to the master
-
-        final Ghostwriter.MasterGhostwriter masterGhostwriter = Ghostwriter.MasterGhostwriter.class.cast(ghostwriter);
-
-        return masterGhostwriter == null
-                || masterGhostwriter.performFromMaster(run, workspace, listener);
-		
+        if (ghostwriter instanceof Ghostwriter.MasterGhostwriter2) {
+            return ((Ghostwriter.MasterGhostwriter2)ghostwriter).performFromMaster(run, workspace, listener);
+        } else if (ghostwriter instanceof Ghostwriter.MasterGhostwriter && run instanceof AbstractBuild) {
+            return ((Ghostwriter.MasterGhostwriter) ghostwriter).performFromMaster((AbstractBuild<?, ?>) run, workspace, listener);
+        }
+        return true;
 	}
 
 	//TODO: this logic undermines error propagation in the code

--- a/src/main/java/hudson/plugins/helpers/Ghostwriter.java
+++ b/src/main/java/hudson/plugins/helpers/Ghostwriter.java
@@ -1,6 +1,7 @@
 package hudson.plugins.helpers;
 
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
@@ -44,7 +45,33 @@ public interface Ghostwriter extends Serializable {
         boolean performFromSlave(BuildProxy build, TaskListener listener) throws InterruptedException, IOException;
     }
 
+    @Deprecated
     public static interface MasterGhostwriter extends Ghostwriter {
+// -------------------------- OTHER METHODS --------------------------
+
+        /**
+         * Runs (on the master) the step over the given build and reports the progress to the listener.
+         *
+         * @param build         The the build.
+         * @param executionRoot The module root on which the build executed.
+         * @param listener      The buildListener.
+         * @return true if the build can continue, false if there was an error
+         *         and the build needs to be aborted.
+         * @throws InterruptedException If the build is interrupted by the user (in an attempt to abort the build.)
+         *                              Normally the {@link hudson.tasks.BuildStep} implementations may simply forward
+         *                              the exception it got from its lower-level functions.
+         * @throws java.io.IOException          If the implementation wants to abort the processing when an {@link java.io.IOException}
+         *                              happens, it can simply propagate the exception to the caller. This will cause
+         *                              the build to fail, with the default error message.
+         *                              Implementations are encouraged to catch {@link java.io.IOException} on its own to
+         *                              provide a better error message, if it can do so, so that users have better
+         *                              understanding on why it failed.
+         */
+        @Deprecated
+        boolean performFromMaster(AbstractBuild<?, ?> build, FilePath executionRoot, TaskListener listener) throws InterruptedException, IOException;
+    }
+
+    public static interface MasterGhostwriter2 extends Ghostwriter {
 // -------------------------- OTHER METHODS --------------------------
 
         /**


### PR DESCRIPTION
This adds `MasterGhostWriter2` which is the new ghostwriter with a `Run` type parameter and leaves `MasterGhostWriter` as using `AbstractBuild` this fixes the compatibility issues. Also on the topic on compatibility this re-adds the `AbstractPublisherImpl` for the remote chance that this api is actually being used by third parties and while chances are low there is an entire blog post series and some other things that reference this class.

I would hold off merging this in pending feedback